### PR TITLE
Default to all tubes instead of only the default one

### DIFF
--- a/bs_queue_age.py
+++ b/bs_queue_age.py
@@ -6,7 +6,10 @@ import beanstalkc
 
 HOST = os.environ.get('HOST', 'localhost')
 PORT = os.environ.get('PORT', 11300)
-TUBES = os.environ.get('TUBES', 'default').split()
+
+bs = beanstalkc.Connection(HOST, PORT)
+
+TUBES = os.environ['TUBES'].split() if 'TUBES' in os.environ else bs.tubes()
 
 def clean_tube(tube):
     return tube.replace('.', '_')


### PR DESCRIPTION
The `queue_age` plugin could return data on all queue instead of defaulting to only `default`.

The only downside I can see is that it needs a beanstalk connection to be created even when the script is called with the `config` parameter
